### PR TITLE
Fix virtual-assembly generation for if expression

### DIFF
--- a/ir_asm_virtual/src/lowering/expr.rs
+++ b/ir_asm_virtual/src/lowering/expr.rs
@@ -456,7 +456,7 @@ pub fn lower_expr<'ctx>(
                 state.push_binder(new_binder);
                 lower_expr(e3, ctx, state);
 
-                let bb_after_if = state.builder.next_basic_block();
+                let bb_after_if = state.builder.current_basic_block();
                 // This call will also fire the deferred terminator creation.
                 state.resolve_label(label_after_if, bb_after_if);
 

--- a/ir_asm_virtual/src/lowering/expr.rs
+++ b/ir_asm_virtual/src/lowering/expr.rs
@@ -169,7 +169,6 @@ impl PlaceBinder {
                         }),
                         target,
                     );
-                    state.builder.set_args_to_current(index_vec![branch_arg]);
                 }
                 PlaceBindee::Call {
                     calling_conv,
@@ -188,7 +187,6 @@ impl PlaceBinder {
                         },
                         target,
                     );
-                    state.builder.set_args_to_current(index_vec![call_result]);
                 }
             },
         }

--- a/tests/if-call.ml
+++ b/tests/if-call.ml
@@ -1,0 +1,4 @@
+let rec f x = x in
+let x = if 0 = 1 then f 2 else f 3 in
+print_int x;
+print_newline ()

--- a/tests/if-nested.ml
+++ b/tests/if-nested.ml
@@ -1,0 +1,3 @@
+let x = if 0 = 1 then if 2 = 3 then 4 else 5 else if 6 = 7 then 8 else 9 in
+print_int x;
+print_newline ()

--- a/tests/if.ml
+++ b/tests/if.ml
@@ -1,0 +1,3 @@
+let x = if 0 = 1 then 2 else 3 in
+print_int x;
+print_newline ()


### PR DESCRIPTION
- [fix basicblock numbering of confluent block](https://github.com/utokyo-compiler/mincaml-rs/commit/d7d1303d6373245199570cefddf7ff810b7ac9c4)
- [remove incorrect block arg insertion](https://github.com/utokyo-compiler/mincaml-rs/commit/6f6e268d7e90a25b2ec7fbb989cb5dcf535b27a4)